### PR TITLE
优化洗碗机的功能和操作逻辑

### DIFF
--- a/custom_components/midea_smart_home/T0xE1.py
+++ b/custom_components/midea_smart_home/T0xE1.py
@@ -48,12 +48,11 @@ DEVICE_MAPPING = {
             },
             Platform.SELECT: {
                 "work_status": {
-                    "status_key": "work_status",
                     "options": {
                         "power_off": {"work_status": "power_off"},
                         "cancel": {"work_status": "cancel"},
                         "pause": {"operator": "pause"},
-                        "start": {"work_status": "work"}
+                        "start": {"work_status": "work", "pending_commands": ["wash_mode", "additional"]}
                     }
                 },
                 "wash_mode": {
@@ -97,7 +96,14 @@ DEVICE_MAPPING = {
                     "translation_key": "cur_temperature"
                 },
                 "softwater": {
-                    "name": "软水档位"
+                    "options": {
+                        "1": {"softwater": 1},
+                        "2": {"softwater": 2},
+                        "3": {"softwater": 3},
+                        "4": {"softwater": 4},
+                        "5": {"softwater": 5}
+                    },
+                    "condition": {"not_eq": ["work_status", "work"]}
                 },
                 "left_time": {
                     "device_class": SensorDeviceClass.DURATION,
@@ -111,12 +117,15 @@ DEVICE_MAPPING = {
                     "state_class": SensorStateClass.MEASUREMENT
                 },
                 "wash_stage": {
-                    "name": "洗涤阶段",
                     "device_class": SensorDeviceClass.ENUM,
-                    "translation_key": "wash_stage",
                     "status_key": "wash_stage",
-                    "options": ["idle", "pre_wash", "sterilizing", "rinse", "drying"],
-                    "options_map": [0, 1, 2, 3, 4]
+                    "options": {
+                        "idle": {"wash_stage": 0},
+                        "pre_wash": {"wash_stage": 1},
+                        "sterilizing": {"wash_stage": 2},
+                        "rinse": {"wash_stage": 3},
+                        "drying": {"wash_stage": 4}
+                    }
                 }
             }
         }

--- a/custom_components/midea_smart_home/device_mapping/T0xE1.py
+++ b/custom_components/midea_smart_home/device_mapping/T0xE1.py
@@ -79,7 +79,9 @@ DEVICE_MAPPING = {
                     "options": {
                         "none": {"additional": 0},
                         "extra_rinse_1": {"additional": 9},
-                        "extra_rinse_2": {"additional": 10}
+                        "extra_rinse_2": {"additional": 10},
+                        "few_dishes_rinse_1": {"additional": 13},
+                        "few_dishes_rinse_2": {"additional": 14}
                     }
                 }
             },
@@ -94,7 +96,14 @@ DEVICE_MAPPING = {
                     "translation_key": "cur_temperature"
                 },
                 "softwater": {
-                    "device_class": SensorDeviceClass.ENUM
+                    "options": {
+                        "1": {"softwater": 1},
+                        "2": {"softwater": 2},
+                        "3": {"softwater": 3},
+                        "4": {"softwater": 4},
+                        "5": {"softwater": 5}
+                    },
+                    "condition": {"not_eq": ["work_status", "work"]}
                 },
                 "left_time": {
                     "device_class": SensorDeviceClass.DURATION,

--- a/custom_components/midea_smart_home/device_mapping/T0xE1.py
+++ b/custom_components/midea_smart_home/device_mapping/T0xE1.py
@@ -8,6 +8,14 @@ DEVICE_MAPPING = {
         "rationale": ["off", "on"],
         "entities": {
             Platform.SWITCH: {
+                "dish_wash": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                    "work_status_key": "work_status",
+                    "defer_update": True,
+                    "pending_commands": ["wash_mode", "additional"],
+                    "start_command": {"work_status": "work"},
+                    "stop_command": {"work_status": "cancel"}
+                },
                 "lock": {
                     "device_class": SwitchDeviceClass.SWITCH,
                 },
@@ -28,9 +36,6 @@ DEVICE_MAPPING = {
                 },
                 "softwater_lack": {
                     "device_class": BinarySensorDeviceClass.PROBLEM
-                },
-                "wash_stage": {
-                    "device_class": BinarySensorDeviceClass.RUNNING
                 }
             },
             Platform.NUMBER: {
@@ -45,27 +50,36 @@ DEVICE_MAPPING = {
                 "work_status": {
                     "options": {
                         "power_off": {"work_status": "power_off"},
-                        "power_on": {"work_status": "power_on"},
                         "cancel": {"work_status": "cancel"},
                         "pause": {"operator": "pause"},
-                        "resume": {"operator": "start"}
+                        "start": {"work_status": "work", "pending_commands": ["wash_mode", "additional"]}
                     }
                 },
                 "wash_mode": {
+                    "defer_update": True,
                     "options": {
-                        "neutral_gear": {"work_status": "cancel", "mode": "neutral_gear"},
-                        "strong_wash": {"work_status": "work", "mode": "strong_wash"},
-                        "standard_wash": {"work_status": "work", "mode": "standard_wash"},
-                        "single_disinfect": {"work_status": "work", "mode": "single_disinfect"},
-                        "eco_wash": {"work_status": "work", "mode": "eco_wash"},
-                        "glass_wash": {"work_status": "work", "mode": "glass_wash"},
-                        "fast_wash": {"work_status": "work", "mode": "fast_wash"},
-                        "soak_wash": {"work_status": "work", "mode": "soak_wash"},
-                        "self_clean": {"work_status": "work", "mode": "self_clean"},
-                        "fruit_wash": {"work_status": "work", "mode": "fruit_wash"},
-                        "germ": {"work_status": "work", "mode": "germ"},
-                        "seafood_wash": {"work_status": "work", "mode": "seafood_wash"},
-                        "hotpot_wash": {"work_status": "work", "mode": "hotpot_wash"}
+                        "neutral_gear": {"mode": "neutral_gear"},
+                        "strong_wash": {"mode": "strong_wash"},
+                        "standard_wash": {"mode": "standard_wash"},
+                        "single_disinfect": {"mode": "single_disinfect"},
+                        "eco_wash": {"mode": "eco_wash"},
+                        "glass_wash": {"mode": "glass_wash"},
+                        "fast_wash": {"mode": "fast_wash"},
+                        "soak_wash": {"mode": "soak_wash"},
+                        "self_clean": {"mode": "self_clean"},
+                        "fruit_wash": {"mode": "fruit_wash"},
+                        "germ": {"mode": "germ"},
+                        "seafood_wash": {"mode": "seafood_wash"},
+                        "hotpot_wash": {"mode": "hotpot_wash"}
+                    }
+                },
+                "additional": {
+                    "defer_update": True,
+                    "status_key": "additional",
+                    "options": {
+                        "none": {"additional": 0},
+                        "extra_rinse_1": {"additional": 9},
+                        "extra_rinse_2": {"additional": 10}
                     }
                 }
             },
@@ -92,6 +106,9 @@ DEVICE_MAPPING = {
                     "device_class": SensorDeviceClass.DURATION,
                     "unit_of_measurement": UnitOfTime.HOURS,
                     "state_class": SensorStateClass.MEASUREMENT
+                },
+                "wash_stage": {
+                    "device_class": SensorDeviceClass.ENUM
                 }
             }
         }

--- a/custom_components/midea_smart_home/entity.py
+++ b/custom_components/midea_smart_home/entity.py
@@ -205,6 +205,11 @@ class MideaBaseEntity(CoordinatorEntity[MideaCoordinator]):
                     return False
             return True
 
+        if "not_eq" in condition:
+            attr, unexpected_value = condition["not_eq"]
+            actual_value = data.get(attr)
+            return actual_value != unexpected_value
+
         if "eq" in condition:
             attr, expected_value = condition["eq"]
             actual_value = data.get(attr)

--- a/custom_components/midea_smart_home/select.py
+++ b/custom_components/midea_smart_home/select.py
@@ -33,6 +33,8 @@ async def async_setup_entry(
                 condition = config.get("condition")
                 status_key = config.get("status_key")
                 ignore_values = config.get("ignore_values")
+                defer_update = config.get("defer_update", False)
+                pending_commands = config.get("pending_commands", [])
                 if isinstance(options, dict):
                     option_list = list(options.keys())
                 else:
@@ -40,7 +42,8 @@ async def async_setup_entry(
                 entities.append(
                     MideaSelectEntity(
                         coordinator, device_id, device_type, sn, sn8, device_name,
-                        select_id, option_list, options, command, translation_key, condition, status_key, ignore_values, model
+                        select_id, option_list, options, command, translation_key, condition, status_key, ignore_values, model,
+                        defer_update, pending_commands
                     )
                 )
 
@@ -48,6 +51,9 @@ async def async_setup_entry(
 
 
 class MideaSelectEntity(MideaBaseEntity, SelectEntity):
+    # Class-level storage for deferred commands per device
+    _pending_commands: dict[int, dict[str, dict]] = {}
+
     def __init__(
         self,
         coordinator: MideaCoordinator,
@@ -65,6 +71,8 @@ class MideaSelectEntity(MideaBaseEntity, SelectEntity):
         status_key: str = None,
         ignore_values: list = None,
         model: str = None,
+        defer_update: bool = False,
+        pending_commands: list[str] = None,
     ):
         config = {"translation_key": translation_key} if translation_key else {}
         super().__init__(
@@ -79,6 +87,11 @@ class MideaSelectEntity(MideaBaseEntity, SelectEntity):
         self._ignore_values = ignore_values or []
         self._attr_options = options
         self._last_option: str | None = None
+        self._defer_update = defer_update
+        self._pending_commands_list = pending_commands or []
+        # Initialize pending commands storage for this device if not exists
+        if self._device_id not in MideaSelectEntity._pending_commands:
+            MideaSelectEntity._pending_commands[self._device_id] = {}
 
     def _is_ignored_value(self, value: Any) -> bool:
         if value is None:
@@ -190,6 +203,25 @@ class MideaSelectEntity(MideaBaseEntity, SelectEntity):
 
         if self._command and isinstance(self._command, dict):
             merged_command.update(self._command)
+
+        # Handle deferred update: store command locally without sending
+        if self._defer_update:
+            MideaSelectEntity._pending_commands[self._device_id][self._select_id] = merged_command
+            return
+
+        # Handle commands that need to merge pending commands (e.g., "start")
+        # First, extract pending_commands from the merged command (it's a config key, not a device command)
+        pending_list = merged_command.pop("pending_commands", None) or self._pending_commands_list
+
+        if pending_list:
+            # Add pending commands from specified entities
+            for pending_id in pending_list:
+                pending = MideaSelectEntity._pending_commands[self._device_id].get(pending_id, {})
+                for key, value in pending.items():
+                    if key not in merged_command:
+                        merged_command[key] = value
+            # Clear pending commands after use
+            MideaSelectEntity._pending_commands[self._device_id] = {}
 
         if merged_command:
             await self.coordinator.async_set_control(merged_command)

--- a/custom_components/midea_smart_home/sensor.py
+++ b/custom_components/midea_smart_home/sensor.py
@@ -36,11 +36,14 @@ async def async_setup_entry(
                 translation_key = config.get("translation_key")
                 state_class = config.get("state_class")
                 suggested_display_precision = config.get("suggested_display_precision")
+                status_key = config.get("status_key")
+                options = config.get("options")
+                options_map = config.get("options_map")
                 entities.append(
                     MideaSensorEntity(
                         coordinator, device_id, device_type, sn, sn8, device_name,
                         sensor_id, name, device_class, unit, translation_key, state_class, model,
-                        suggested_display_precision
+                        suggested_display_precision, status_key, options, options_map
                     )
                 )
 
@@ -79,6 +82,9 @@ class MideaSensorEntity(MideaBaseEntity, SensorEntity):
         state_class: Optional[SensorStateClass] = None,
         model: str = None,
         suggested_display_precision: Optional[int] = None,
+        status_key: str = None,
+        options: list = None,
+        options_map: list = None,
     ):
         config = {"translation_key": translation_key} if translation_key else {}
         super().__init__(
@@ -86,6 +92,14 @@ class MideaSensorEntity(MideaBaseEntity, SensorEntity):
             platform_name="sensor", config=config
         )
         self._sensor_id = sensor_id
+        self._status_key = status_key
+        self._options = options
+        self._options_map = options_map
+        self._reverse_options = None
+
+        if options and isinstance(options, list) and self._options_map and isinstance(self._options_map, list):
+            # options_map is a list of raw values, map by index
+            self._reverse_options = {v: options[i] for i, v in enumerate(self._options_map)}
 
         if device_class and isinstance(device_class, str):
             try:
@@ -106,6 +120,8 @@ class MideaSensorEntity(MideaBaseEntity, SensorEntity):
             self._attr_state_class = state_class
         elif device_class == SensorDeviceClass.ENUM:
             self._attr_state_class = None
+            if options and isinstance(options, list):
+                self._attr_options = options
         elif device_class == SensorDeviceClass.ENERGY:
             self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         elif device_class in (SensorDeviceClass.TEMPERATURE, SensorDeviceClass.HUMIDITY,
@@ -122,10 +138,14 @@ class MideaSensorEntity(MideaBaseEntity, SensorEntity):
             return None
 
         data = self.coordinator.data or {}
-        value = data.get(self._sensor_id)
+        key = self._status_key or self._sensor_id
+        value = data.get(key)
 
         if value is None or value == "":
             return None
+
+        if self._reverse_options and value in self._reverse_options:
+            return self._reverse_options[value]
 
         return value
 

--- a/custom_components/midea_smart_home/switch.py
+++ b/custom_components/midea_smart_home/switch.py
@@ -32,10 +32,16 @@ async def async_setup_entry(
                 condition = config.get("condition")
                 command = config.get("command")
                 include_current = config.get("include_current")
+                defer_update = config.get("defer_update", False)
+                pending_commands = config.get("pending_commands", [])
+                work_status_key = config.get("work_status_key")
+                start_command = config.get("start_command")
+                stop_command = config.get("stop_command")
                 entities.append(
                     MideaSwitchEntity(
                         coordinator, device_id, device_type, sn, sn8, device_name,
-                        switch_id, translation_key, switch_rationale, condition, command, include_current, model
+                        switch_id, translation_key, switch_rationale, condition, command, include_current, model,
+                        defer_update, pending_commands, work_status_key, start_command, stop_command
                     )
                 )
 
@@ -44,6 +50,8 @@ async def async_setup_entry(
 
 class MideaSwitchEntity(MideaBaseEntity, SwitchEntity):
     _attr_device_class = SwitchDeviceClass.SWITCH
+    # Class-level storage for deferred commands per device
+    _pending_commands: dict[int, dict[str, dict]] = {}
 
     def __init__(
         self,
@@ -60,6 +68,11 @@ class MideaSwitchEntity(MideaBaseEntity, SwitchEntity):
         command: dict = None,
         include_current: list = None,
         model: str = None,
+        defer_update: bool = False,
+        pending_commands: list[str] = None,
+        work_status_key: str = None,
+        start_command: dict = None,
+        stop_command: dict = None,
     ):
         config = {"translation_key": translation_key} if translation_key else {}
         super().__init__(
@@ -69,6 +82,14 @@ class MideaSwitchEntity(MideaBaseEntity, SwitchEntity):
         self._switch_id = switch_id
         self._command = command
         self._include_current = include_current or []
+        self._defer_update = defer_update
+        self._pending_commands_list = pending_commands or []
+        self._work_status_key = work_status_key
+        self._start_command = start_command
+        self._stop_command = stop_command
+        # Initialize pending commands storage for this device if not exists
+        if self._device_id not in MideaSwitchEntity._pending_commands:
+            MideaSwitchEntity._pending_commands[self._device_id] = {}
 
     def _get_status_on_off(self, attribute_key: str) -> bool:
         data = self.coordinator.data or {}
@@ -88,9 +109,39 @@ class MideaSwitchEntity(MideaBaseEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool:
+        # If work_status_key is configured, use it to determine switch state
+        if self._work_status_key:
+            data = self.coordinator.data or {}
+            work_status = data.get(self._work_status_key)
+            # Check if work_status indicates "working" state
+            return work_status == "work" or work_status == 8
         return self._get_status_on_off(self._switch_id)
 
     async def _async_set_status_on_off(self, attribute_key: str, turn_on: bool) -> None:
+        # Handle deferred update mode (dish_wash switch)
+        if self._defer_update:
+            merged_command = {}
+            if turn_on and self._start_command:
+                merged_command.update(self._start_command)
+            elif not turn_on and self._stop_command:
+                merged_command.update(self._stop_command)
+
+            # If turning on, merge pending commands from specified entities
+            if turn_on and self._pending_commands_list:
+                from .select import MideaSelectEntity
+                for pending_id in self._pending_commands_list:
+                    pending = MideaSelectEntity._pending_commands[self._device_id].get(pending_id, {})
+                    for key, value in pending.items():
+                        if key not in merged_command:
+                            merged_command[key] = value
+                # Clear pending commands after use
+                MideaSwitchEntity._pending_commands[self._device_id] = {}
+
+            if merged_command:
+                await self.coordinator.async_set_control(merged_command)
+            return
+
+        # Original logic for non-defer switches
         value = self._rationale[int(turn_on)]
         merged_command = {}
         if isinstance(self._command, dict):


### PR DESCRIPTION
1.增加了洗碗机“附加功能”的支持
2.目前的逻辑是一选择模式就会开始洗碗，不符合设备的操作逻辑。增加了一个开关，用来启动洗碗机。修改设备操作逻辑为，选择模式和附加功能后，打开开关开始洗碗，与美的美居APP操作逻辑一致。
3.洗涤阶段不应该是binary_sensor,将其修改为了sensor并映射了对应状态