### PR TITLE
fix: send temperature value based on device precision setting

### DIFF
--- a/custom_components/midea_smart_home/water_heater.py
+++ b/custom_components/midea_smart_home/water_heater.py
@@ -190,7 +190,10 @@ class MideaWaterHeaterEntity(MideaBaseEntity, WaterHeaterEntity):
             new_status[self._key_target_temperature[0]] = temp_int
             new_status[self._key_target_temperature[1]] = temp_dec
         else:
-            new_status[self._key_target_temperature] = temperature
+            if self._attr_precision == 1.0:
+                new_status[self._key_target_temperature] = temp_int
+            else:
+                new_status[self._key_target_temperature] = temperature
         await self.coordinator.async_set_controls(new_status)
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:


### PR DESCRIPTION
HomeKit and Google Home send temperature as float (e.g. 42.5) even
when the device only accepts whole degrees. Check precision setting
to determine whether to send integer or float.


## What

Fix water heater `async_set_temperature` to respect the device's
precision setting when receiving temperature values from external
platforms like HomeKit and Google Home.

## Why

HomeKit Bridge and Google Home send temperature as float values
(e.g. 42.5) via `set_temperature`, even when the device only
supports whole degrees (precision: PRECISION_WHOLE). The original
code forwards the raw float directly to the device, which may
cause the device to reject the value or behave unexpectedly.

## How

In the single-key branch, check `self._attr_precision`:
- `PRECISION_WHOLE` (1.0): send integer (42)
- Otherwise: send raw float (42.5)

The list branch is unchanged.

## Affected devices

| Device | Type | Precision | Impact |
|--------|------|-----------|--------|
| 0xE2 | Electric water heater | WHOLE | HomeKit/Google Home float → int |
| 0xE3 | Gas water heater | WHOLE | HomeKit/Google Home float → int |
| 0xE6 | Boiler (bath) | WHOLE | HomeKit/Google Home float → int |

## Tested

- 0xE2 electric water heater: HomeKit Bridge sets temperature
  correctly, device receives integer value as expected.